### PR TITLE
Capture and send active tab screenshot

### DIFF
--- a/components/background.js
+++ b/components/background.js
@@ -221,12 +221,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           ) {
             const dataUrl = await chrome.tabs.captureVisibleTab(
               currentTab.windowId,
-              { format: 'png' },
+              { format: 'jpeg', quality: 80 },
             );
             if (dataUrl) {
               selectedLocalFiles.unshift({
-                name: 'screenshot.png',
-                type: 'image/png',
+                name: 'screenshot.jpg',
+                type: 'image/jpeg',
                 dataUrl,
               });
             }

--- a/components/background.js
+++ b/components/background.js
@@ -210,6 +210,31 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         const selectedLLMProvider =
           message.llmProvider || (await getLLMProvider());
 
+        // If only the current active tab is selected and it's not an LLM page,
+        // capture a screenshot of the visible area and include it as an attachment
+        try {
+          if (
+            Array.isArray(message.tabIds) &&
+            message.tabIds.length === 1 &&
+            message.tabIds[0] === tabId &&
+            !isLLMPage(currentTab?.url || '')
+          ) {
+            const dataUrl = await chrome.tabs.captureVisibleTab(
+              currentTab.windowId,
+              { format: 'png' },
+            );
+            if (dataUrl) {
+              selectedLocalFiles.unshift({
+                name: 'screenshot.png',
+                type: 'image/png',
+                dataUrl,
+              });
+            }
+          }
+        } catch (screenshotErr) {
+          console.error('[background] screenshot capture failed:', screenshotErr);
+        }
+
         // Check if current tab matches the selected LLM provider
         const currentTabMatchesSelectedLLM =
           currentTab.url &&


### PR DESCRIPTION
Capture and attach a screenshot of the active tab when it's the sole context sent to the LLM from a non-LLM page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6d81374-649c-48a0-b067-8a7781a81b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6d81374-649c-48a0-b067-8a7781a81b2a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

