### PR TITLE
Check and disable unscriptable llm providers

### DIFF
--- a/components/background.js
+++ b/components/background.js
@@ -158,10 +158,11 @@ async function disableProviderAndNotify(providerId) {
     try {
       chrome.notifications.create({
         type: 'basic',
-        iconUrl: 'icons/icon-128x128.png',
+        iconUrl: chrome.runtime.getURL('icons/icon-128x128.png'),
         title: 'Provider disabled',
         message: `${providerName} cannot be scripted in this browser. It has been disabled in Bear Talk.`,
         silent: false,
+        requireInteraction: true,
       });
     } catch (e) {
       console.warn('Notification failed:', e);
@@ -273,7 +274,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             }
           }
         } catch (screenshotErr) {
-          console.error('[background] screenshot capture failed:', screenshotErr);
+          console.error(
+            '[background] screenshot capture failed:',
+            screenshotErr,
+          );
         }
 
         // Check if current tab matches the selected LLM provider
@@ -319,6 +323,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           });
           if (newTab.id) {
             const ok = await injectScriptToPasteFilesAsAttachments(newTab.id);
+            console.log(
+              '[background] injectScriptToPasteFilesAsAttachments',
+              ok,
+            );
             if (!ok) {
               await clearLoadingBadge();
               isProcessing = false;

--- a/components/options.js
+++ b/components/options.js
@@ -81,13 +81,15 @@ const createLLMOption = (provider, disabled = false) => {
           ? `<img src="${faviconUrl}" alt="${name} icon" class="w-6 h-6 rounded">`
           : ''
       }
-      <span class="label-text text-gray-600 dark:text-gray-300">${name}${
-        disabled ? ' (disabled)' : ''
-      }</span>
+      <span class="label-text text-gray-600 dark:text-gray-300 ${
+        disabled && 'line-through'
+      }" title="${
+    disabled ? 'Disabled due to browser restrictions' : ''
+  }">${name}</span>
     </div>
     <input type="radio" name="llm-option" class="radio radio-primary" value="${provider}" ${
-      disabled ? 'disabled' : ''
-    } />
+    disabled ? 'disabled' : ''
+  } />
   `;
 
   // Add immediate save listener to the radio input
@@ -374,7 +376,10 @@ async function init() {
     if (firstEnabled && firstEnabled !== llmProvider) {
       await setLLMProvider(firstEnabled);
       llmProvider = firstEnabled;
-      showStatus('The previously selected provider was disabled and has been switched.', true);
+      showStatus(
+        'The previously selected provider was disabled and has been switched.',
+        true,
+      );
     }
   }
   updateLLMOptionValue(llmProvider, true);

--- a/components/popup.js
+++ b/components/popup.js
@@ -435,8 +435,9 @@ async function createAIMenu() {
   // If any providers are disabled, show a small notice
   if (Array.from(disabledProviders).length > 0) {
     const notice = document.createElement('div');
-    notice.className = 'px-3 pt-2 text-xs text-warning';
-    notice.textContent = 'Some providers are disabled due to browser restrictions.';
+    notice.className = 'px-3 py-2 text-xs text-warning';
+    notice.textContent =
+      'Some providers are disabled due to browser restrictions.';
     aiList.appendChild(notice);
   }
 
@@ -448,7 +449,9 @@ async function createAIMenu() {
       isDisabled
         ? 'opacity-40 cursor-not-allowed'
         : 'cursor-pointer transition-colors duration-200 ' +
-          (isSelected ? 'bg-primary/10 hover:bg-primary/20' : 'hover:bg-base-200')
+          (isSelected
+            ? 'bg-primary/10 hover:bg-primary/20'
+            : 'hover:bg-base-200')
     }`;
     menuItem.dataset.provider = provider.id;
 
@@ -787,7 +790,7 @@ async function sendPromptToLLM() {
   ) {
     window.close();
     return;
-    }
+  }
 
   // Ask the background service-worker to collect the context and process it
   chrome.runtime.sendMessage({

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,8 @@
     "scripting",
     "storage",
     "webRequest",
-    "downloads"
+    "downloads",
+    "notifications"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
Automatically disable LLM providers that cannot be scripted in the browser and notify the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8f22311-904c-4388-b04a-ae3d7d93c260">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8f22311-904c-4388-b04a-ae3d7d93c260">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

